### PR TITLE
docs: connect Ziwei Knows product ecosystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ coverage/
 # Misc
 *.tgz
 .eslintcache
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -1,62 +1,112 @@
 <p align="center">
-  <img width="820" alt="紫微知道" src="./docs/assets/logo.svg" />
+  <img width="820" alt="紫微知道·星盘 - Ziwei Chart" src="./docs/assets/logo.svg" />
 </p>
 
 <p align="center">
-  简体中文 ·
-  <a href="./docs/README.zh-TW.md">繁體中文</a> ·
-  <a href="./docs/README.ja.md">日本語</a> ·
-  <a href="./docs/README.en.md">English</a>
+  简体中文 · <a href="./docs/README.zh-TW.md">繁體中文</a> · <a href="./docs/README.ja.md">日本語</a> · <a href="./docs/README.en.md">English</a>
 </p>
 
-<p align="center">
-  <strong>现代化的紫微斗数命盘分析工具</strong>
-</p>
+<h1 align="center">紫微知道 · 星盘 | Ziwei Chart</h1>
+
+<p align="center"><strong>准确生成、浏览与理解你的紫微斗数命盘。</strong></p>
+<p align="center">一个面向普通用户的开源命盘工具，结合确定性排盘、出生地与真太阳时校正、可视化趋势分析和可选 AI 解读。</p>
 
 <p align="center">
-  精准排盘 · AI 深度解读 · 年度运势 · 双人合盘 · 人生 K 线
+  <a href="https://zwknows.vercel.app/"><strong>在线体验 Ziwei Chart</strong></a> ·
+  <a href="#紫微知道产品生态">认识紫微知道产品生态</a>
 </p>
 
 <p align="center">
   <a href="https://github.com/ruijayfeng/ziwei"><img alt="Stars" src="https://img.shields.io/github/stars/ruijayfeng/ziwei?style=social" /></a>
   <a href="https://github.com/ruijayfeng/ziwei"><img alt="Forks" src="https://img.shields.io/github/forks/ruijayfeng/ziwei?style=social" /></a>
   <a href="https://github.com/ruijayfeng/ziwei/blob/main/LICENSE"><img alt="GPLv3 License" src="https://img.shields.io/badge/License-GPLv3-blue.svg" /></a>
-  <a href="https://www.typescriptlang.org/"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-5.9-blue" /></a>
-  <a href="https://react.dev/"><img alt="React" src="https://img.shields.io/badge/React-19-61DAFB" /></a>
-  <a href="https://vite.dev/"><img alt="Vite" src="https://img.shields.io/badge/Vite-7-646CFF" /></a>
+  <img alt="TypeScript 5.9" src="https://img.shields.io/badge/TypeScript-5.9-blue" />
+  <img alt="React 19" src="https://img.shields.io/badge/React-19-61DAFB" />
+  <img alt="Vite 7" src="https://img.shields.io/badge/Vite-7-646CFF" />
 </p>
 
-<p align="center">
-  <img width="1920" height="911" alt="紫微知道界面预览" src="https://github.com/user-attachments/assets/756c0de6-e31c-4166-913e-c2d0afd1cf15" />
-</p>
+<!-- Future Ziwei Knows mascot variation for Ziwei Chart goes here. -->
 
-## 概览
+---
 
-紫微知道把传统紫微斗数知识、现代前端交互和多模型 AI 能力整合到一个可自部署的 Web 应用中。
+## 紫微知道产品生态
 
-它不只是展示命盘，而是围绕“看得懂、用得上、方便分享”这三件事，提供更完整的分析体验。
+紫微知道（Ziwei Knows）由三款平级、互补的开源产品组成。它们服务不同的探索方式，不要求账号、命盘或数据互通。
 
-## 功能特性
+| 产品 | 适合什么需求 | 访问 |
+| --- | --- | --- |
+| **Ziwei Chart** `当前产品` | 想准确排盘、浏览十二宫、趋势、流年或合盘。 | [在线体验](https://zwknows.vercel.app/) · [GitHub](https://github.com/ruijayfeng/ziwei) |
+| **Ziwei Chat** | 已有命盘，想围绕事业、关系、财富或近况继续追问。 | [开始对话](https://ziweichat.vercel.app/) · [GitHub](https://github.com/ruijayfeng/ziwei_chat) |
+| **ZATI** | 不想先填写出生信息，想通过行为选择探索人格原型。 | [查看项目](https://github.com/ruijayfeng/ZATI) |
 
-- **精准排盘** - 基于 `iztro`，支持完整十二宫配置与传统安星逻辑
-- **AI 命盘解读** - 提供结构化的命盘分析，支持多模型接入
-- **年度运势** - 结合限流叠宫与月度趋势，呈现阶段性变化
-- **双人合盘** - 支持四化互飞、关系匹配与互动分析
-- **人生 K 线** - 以可视化方式展示长期运势走势
-- **分享卡片** - 一键生成适合传播的命格金句卡
+如果你想先看清盘面和长期趋势，留在 Ziwei Chart；如果你更关心一个具体问题，试试 [在 Ziwei Chat 中追问命盘](https://ziweichat.vercel.app/)；如果你想从行为倾向开始，也可以探索 [ZATI 东方人格原型](https://github.com/ruijayfeng/ZATI)。
 
-## 技术栈
+## 这是什么
 
-- React 19
-- TypeScript
-- Vite
-- Tailwind CSS
-- Zustand
-- ECharts / Recharts
-- `iztro`
-- OpenAI-compatible LLM API
+**Ziwei Chart** 是紫微知道系列中的命盘与可视化分析产品。输入出生日期、时间、性别与出生地后，应用使用 `iztro` 生成确定性紫微斗数命盘；出生地匹配与真太阳时校正帮助用户更接近可解释的排盘基础。
+
+它的重点不是用一段笼统文字替代命盘，而是让用户先看见十二宫、星曜、年度趋势、关系互动和人生走势，再决定是否需要 AI 辅助解读或进一步对话。
+
+## 核心能力
+
+| 能力 | 说明 |
+| --- | --- |
+| **确定性排盘** | 基于 [iztro](https://github.com/SylarLong/iztro) 生成十二宫与传统安星结果，不由模型自行推算。 |
+| **出生地与真太阳时** | 通过本地城市坐标匹配降低用户填写门槛，并支持真太阳时校正。 |
+| **年度运势** | 结合限流叠宫与月度趋势，浏览阶段性变化。 |
+| **双人合盘** | 用四化互飞、关系匹配与互动视角理解两张命盘。 |
+| **人生 K 线** | 以图形方式浏览长期走势，帮助用户定位不同人生阶段。 |
+| **AI 辅助解读** | 可接入兼容 OpenAI API 的模型；命盘事实仍由确定性工具提供。 |
+| **分享卡片** | 将分析结果生成适合保存和传播的视觉卡片。 |
+
+## 界面预览
+
+### 信息填写
+<img width="1920" height="911" alt="Ziwei Chart 出生信息与出生地填写页面" src="https://github.com/user-attachments/assets/7e7cce4f-11bd-4cbd-beee-7e6fc0c1280a" />
+
+### 命盘展示
+<img width="1920" height="911" alt="Ziwei Chart 十二宫命盘展示页面" src="https://github.com/user-attachments/assets/756c0de6-e31c-4166-913e-c2d0afd1cf15" />
+
+### 解读、运势与关系分析
+<img width="1920" height="911" alt="Ziwei Chart 命盘解读结果页面" src="https://github.com/user-attachments/assets/3f151263-587d-4fdc-8017-e9eabdf6b47f" />
+<img width="1646" height="1990" alt="Ziwei Chart 年度运势趋势页面" src="https://github.com/user-attachments/assets/a79ba231-2e8f-4b08-a510-7eb456e40cbc" />
+<img width="1920" height="911" alt="Ziwei Chart 双人合盘分析页面" src="https://github.com/user-attachments/assets/88407e8a-7a7b-4be4-ba5d-20eaaddcd996" />
+
+## 工作原理与边界
+
+```text
+出生信息 + 出生地
+  -> 日期规范化与真太阳时校正
+  -> iztro 确定性排盘
+  -> 命盘、趋势、合盘与人生 K 线可视化
+  -> 可选 AI 解读与本地知识上下文
+```
+
+- 命盘宫位、星曜与排盘事实来自确定性排盘引擎。
+- AI 用于解释与组织信息，不应被视为自行计算命盘或给出确定结论。
+- 本产品提供的是文化与自我探索工具，不替代医疗、法律、投资、心理或职业专业建议。
+
+## 常见问题
+
+### Ziwei Chart 和 Ziwei Chat 有什么区别？
+
+Ziwei Chart 用于生成和可视化浏览命盘、趋势、合盘等结构化信息；[Ziwei Chat](https://github.com/ruijayfeng/ziwei_chat) 用于围绕这些事实进行自然语言追问，并展示工具、知识来源和回答质检证据。
+
+### 为什么需要出生地和真太阳时？
+
+出生地可用于匹配当地坐标；在你选择校正时，应用根据坐标计算真太阳时。用户不需要手动填写经纬度或分钟修正值。
+
+### 不配置模型也能使用吗？
+
+可以。排盘、趋势、合盘、人生 K 线和本地浏览功能不依赖模型。只有 AI 解读需要在应用设置中配置兼容 OpenAI API 的服务。
+
+### 命盘事实和 AI 解读是一回事吗？
+
+不是。命盘事实由 `iztro` 和输入信息确定；AI 解读是对这些事实与知识上下文的辅助说明。两者应被清楚区分。
 
 ## 快速开始
+
+环境要求：Node.js 22+、npm 10+。
 
 ```bash
 git clone https://github.com/ruijayfeng/ziwei.git
@@ -65,7 +115,11 @@ npm install
 npm run dev
 ```
 
-开发服务器启动后，在浏览器打开终端输出的本地地址即可。
+启动后，在浏览器打开终端输出的本地地址。
+
+## 配置模型
+
+在应用内打开设置，填写兼容 OpenAI API 的 Provider、Base URL、API Key 与 Model。当前支持 Kimi、Gemini、Claude、DeepSeek 等兼容接口；模型配置仅用于 AI 解读能力。
 
 ## 部署
 
@@ -73,7 +127,7 @@ npm run dev
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/ruijayfeng/ziwei&project-name=ziwei&root-directory=app)
 
-点击仓库部署按钮或手动导入项目时，将 **Root Directory** 设置为 `app`。
+导入时将 **Root Directory** 设置为 `app`。
 
 ### Cloudflare Pages
 
@@ -84,69 +138,28 @@ npm run dev
 - Build command: `npm run build`
 - Build output directory: `dist`
 
-## 配置
-
-在应用内打开设置，即可配置 LLM API。
-
-支持接入 OpenAI-compatible 接口，也可配置以下服务：
-
-| 服务商 | 地址 |
-| --- | --- |
-| Kimi | https://platform.moonshot.cn/ |
-| Gemini | https://ai.google.dev/ |
-| Claude | https://console.anthropic.com/ |
-| DeepSeek | https://platform.deepseek.com/ |
-
 ## 项目结构
 
 ```text
 app/
 ├── src/
-│   ├── components/     # 业务组件
-│   │   ├── chart/      # 命盘展示
-│   │   ├── kline/      # 人生 K 线
-│   │   ├── fortune/    # 年度运势
-│   │   ├── match/      # 双人合盘
-│   │   └── share/      # 分享卡片
-│   ├── lib/            # 领域工具与适配层
-│   ├── knowledge/      # 紫微知识库
+│   ├── components/     # 命盘、趋势、合盘、分享与设置界面
+│   ├── lib/            # 日期、地点、真太阳时与领域工具
+│   ├── knowledge-db/   # 结构化知识检索
+│   ├── knowledge/      # 静态紫微知识
 │   └── stores/         # 状态管理
 └── package.json
 ```
 
-## 截图
+## 开源协议与致谢
 
-### 信息填写
-<img width="1920" height="911" alt="信息填写页面" src="https://github.com/user-attachments/assets/7e7cce4f-11bd-4cbd-beee-7e6fc0c1280a" />
-
-### 命盘展示
-<img width="1920" height="911" alt="命盘展示" src="https://github.com/user-attachments/assets/756c0de6-e31c-4166-913e-c2d0afd1cf15" />
-
-### 解读结果
-<img width="1920" height="911" alt="解读结果" src="https://github.com/user-attachments/assets/3f151263-587d-4fdc-8017-e9eabdf6b47f" />
-
-### 年度运势
-<img width="1646" height="1990" alt="年度运势" src="https://github.com/user-attachments/assets/a79ba231-2e8f-4b08-a510-7eb456e40cbc" />
-
-### 人生 K 线
-<img width="1920" height="911" alt="人生 K 线" src="https://github.com/user-attachments/assets/09b64812-d247-4189-912b-0abea6051881" />
-
-### 双人合盘
-<img width="1920" height="911" alt="双人合盘" src="https://github.com/user-attachments/assets/88407e8a-7a7b-4be4-ba5d-20eaaddcd996" />
-
-### 分享卡片
-<img width="1920" height="911" alt="分享卡片" src="https://github.com/user-attachments/assets/921faecb-a35f-4386-85bf-89abf03f69d9" />
-
-## 开源协议
-
-GPLv3 License
-
-## 致谢
+本项目按 [GPLv3 License](./LICENSE) 发布。
 
 - [iztro](https://github.com/SylarLong/iztro)
 - [lifekline](https://github.com/AICryptoHK/lifekline)
-- [ClaudeCode 镜像站](https://www.aicodemirror.com/register?invitecode=R2A5HD)
 
-## Star History
+---
 
-[![Star History Chart](https://api.star-history.com/image?repos=ruijayfeng/ziwei&type=timeline&legend=top-left)](https://www.star-history.com/?repos=ruijayfeng%2Fziwei&type=timeline&legend=top-left)
+<p align="center">如果 Ziwei Chart 对你有帮助，欢迎点亮 Star，也欢迎探索紫微知道的 <a href="https://github.com/ruijayfeng/ziwei_chat">Ziwei Chat</a> 与 <a href="https://github.com/ruijayfeng/ZATI">ZATI</a>。</p>
+
+[![Star History Chart](https://api.star-history.com/image?repos=ruijayfeng/ziwei&type=timeline&legend=top-left)](https://www.star-history.com/?repos=ruijayfeng%2Fziwei&type=timeline)

--- a/docs/superpowers/plans/2026-07-21-ziwei-knows-readme-ecosystem.md
+++ b/docs/superpowers/plans/2026-07-21-ziwei-knows-readme-ecosystem.md
@@ -1,0 +1,168 @@
+# Ziwei Knows README Ecosystem Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the Chart, Chat, and ZATI README files into complementary product landing pages with a shared Ziwei Knows ecosystem navigation.
+
+**Architecture:** Each repository retains a self-contained README and its actual setup, deployment, and license information. A repeated Markdown ecosystem section links the three peer products by user need, while product-specific hero copy, FAQs, and visual placeholders preserve distinct acquisition intent.
+
+**Tech Stack:** GitHub-flavored Markdown, existing repository images, GitHub relative links, npm and pnpm command documentation.
+
+## Global Constraints
+
+- Products are peers; no README represents one as the parent of another.
+- Ziwei Chart receives extra ecosystem discovery content because it has stronger traffic, not product rank.
+- Keep the existing Ziwei Chat mascot and leave all new or changed logo assets as explicit placeholders.
+- Do not claim account, profile, chart, or data interoperability that does not exist.
+- Preserve documented commands, deployment behavior, and license terms.
+- Use existing `ruijayfeng/*` repository URLs until the organization transfer is complete.
+
+---
+
+### Task 1: Establish Shared Ecosystem Copy
+
+**Files:**
+- Modify: `D:\Ziwei\ziweiknowV1\README.md`
+- Modify: `D:\Ziwei\ziwei_chat\README.md`
+- Modify: `D:\Ziwei\ZATI\README.md`
+
+**Interfaces:**
+- Consumes: the three current public repository URLs.
+- Produces: a three-product `Ziwei Knows Product Ecosystem` section with each current product labelled and all links resolvable.
+
+- [ ] **Step 1: Add peer product cards after the hero and before the current product overview**
+
+Use the same three products in every README: Ziwei Chart for visual chart
+exploration, Ziwei Chat for evidence-backed chart conversation, and ZATI for
+Eastern archetype self-exploration. Mark only the current repository as
+`Current product`.
+
+- [ ] **Step 2: Verify peer positioning and links**
+
+Run: `rg -n "parent product|next step|Ziwei Knows Product Ecosystem|ruijayfeng/(ziwei|ziwei_chat|ZATI)" README.md`
+
+Expected: every ecosystem section links the three repositories without calling
+any product a parent or required prerequisite.
+
+### Task 2: Rewrite Ziwei Chart as the High-Traffic Product Entry
+
+**Files:**
+- Modify: `D:\Ziwei\ziweiknowV1\README.md`
+
+**Interfaces:**
+- Consumes: existing screenshots, translated README entry points, Vercel URL,
+  Vite commands, GPLv3 license, and deterministic chart features.
+- Produces: a user-first Chart README that preserves multilingual and
+  self-hosting discovery value.
+
+- [ ] **Step 1: Replace generic hero copy with Chart-specific product identity and primary online CTA**
+
+State that Chart is for deterministic Zi Wei Dou Shu chart creation and visual
+exploration. Keep the existing Chart logo asset. Add a clearly labelled
+placeholder for a future mascot variation rather than generating an image.
+
+- [ ] **Step 2: Add need-based product discovery and Chart FAQ**
+
+Document the difference between Chart and Chat, birth data and true solar time,
+local model configuration, and the difference between chart facts and AI
+interpretation.
+
+- [ ] **Step 3: Preserve functional setup and deployment documentation**
+
+Keep `app` as the project root, `npm run dev`, Vercel, Cloudflare Pages, and
+the existing screenshot gallery intact.
+
+### Task 3: Adapt Ziwei Chat Without Replacing Its Existing Design Language
+
+**Files:**
+- Modify: `D:\Ziwei\ziwei_chat\README.md`
+
+**Interfaces:**
+- Consumes: the current Zhiwei mascot, Next.js runtime, optional database modes,
+  Apache-2.0 license, and documented command set.
+- Produces: a Chat README that keeps the current hierarchy while clearly naming
+  it as the Chat member of the Ziwei Knows product family.
+
+- [ ] **Step 1: Preserve the hero mascot and revise only its brand framing**
+
+Keep `docs/images/zhiwei-mark.png` unchanged. Add the product name `Ziwei
+Knows · Chat` without changing the companion identity `Zhiwei`.
+
+- [ ] **Step 2: Insert the shared ecosystem block and product-specific FAQ**
+
+Cover deterministic chart facts, evidence, privacy, local mode, and when users
+may prefer visual exploration in Chart or behavioral self-exploration in ZATI.
+
+- [ ] **Step 3: Keep runtime, database, evaluation, deployment, and license copy accurate**
+
+Retain current commands and the explicit database-optional deployment model.
+
+### Task 4: Turn ZATI into a Conversion-Focused Peer Product README
+
+**Files:**
+- Modify: `D:\Ziwei\ZATI\README.md`
+
+**Interfaces:**
+- Consumes: current quick and standard assessment modes, four-axis scoring,
+  sixteen archetypes, local progress, pnpm commands, and prototype license
+  state.
+- Produces: a ZATI README that makes its non-diagnostic scope and distinct
+  product value clear.
+
+- [ ] **Step 1: Reframe the hero around product use and preserve a mascot-art placeholder**
+
+Use the full product name and a primary test CTA placeholder. Do not claim a
+public URL until one is supplied. Reserve an explicit slot for a future Zhiwei
+mascot variation.
+
+- [ ] **Step 2: Add the shared ecosystem block and ZATI FAQ**
+
+Explain the 24/56-question modes, scoring boundaries, local storage, lack of
+diagnostic claims, and the optional relationship to Chart and Chat.
+
+- [ ] **Step 3: Preserve implementation evidence and command correctness**
+
+Keep the React/Vite stack, all pnpm scripts, the current MVP state, and the
+unpublished license status.
+
+### Task 5: Validate and Commit Each Repository Separately
+
+**Files:**
+- Verify: `D:\Ziwei\ziweiknowV1\README.md`
+- Verify: `D:\Ziwei\ziwei_chat\README.md`
+- Verify: `D:\Ziwei\ZATI\README.md`
+
+**Interfaces:**
+- Consumes: completed Markdown files.
+- Produces: clean Markdown diffs with valid relative assets and live external
+  repository links.
+
+- [ ] **Step 1: Check Markdown references and diff whitespace**
+
+Run in each repository:
+
+```powershell
+git diff --check
+rg -n "docs/images/zhiwei-mark.png|docs/assets/logo.svg|ruijayfeng/(ziwei|ziwei_chat|ZATI)" README.md
+```
+
+Expected: no whitespace errors; every referenced local asset exists; every
+ecosystem repository URL is present.
+
+- [ ] **Step 2: Review for unsupported claims**
+
+Run in each repository:
+
+```powershell
+rg -n "shared account|shared data|required prerequisite|diagnosis|guaranteed" README.md
+```
+
+Expected: no shared-data or required-prerequisite claim; ZATI's non-diagnostic
+boundary remains explicit.
+
+- [ ] **Step 3: Commit each repository separately**
+
+```powershell
+git add README.md
+git commit -m "docs: connect Ziwei Knows product ecosystem"
+```

--- a/docs/superpowers/specs/2026-07-21-ziwei-knows-readme-ecosystem-design.md
+++ b/docs/superpowers/specs/2026-07-21-ziwei-knows-readme-ecosystem-design.md
@@ -79,15 +79,21 @@ locations. They will be updated together after transfer to `ziweiknows/*`.
 Ziwei Chat is the visual reference for information density, hierarchy, dividers,
 tables, and restrained use of assets. It is not a template to copy verbatim.
 
-- Chart keeps the existing `docs/assets/logo.svg` as a Chart-specific hero asset.
-  Its tagline, `let the chart speak`, describes Chart and must not become a
-  series-wide claim.
-- Chat keeps the `Zhiwei` companion mark as its product-specific emotional cue.
-- ZATI keeps a typographic `ZATI` hero until it has an independently designed
-  archetype mark; do not reuse Chat's character or Chart's logo.
-- The shared ecosystem block uses a text brand lockup, `Ziwei Knows / 紫微知道`,
-  rather than a product logo. This avoids implying one product owns
-  the whole series.
+- The existing `Zhiwei` companion mark is the series mascot and shared visual
+  identity. Ziwei Chat keeps that exact mark unchanged.
+- Chart retains its existing `docs/assets/logo.svg` as its current hero asset.
+  Its `let the chart speak` tagline remains Chart-specific, but future Chart
+  mascot artwork must use the Zhiwei mark as a character reference.
+- ZATI's future archetype artwork must use the Zhiwei mark as a character
+  reference. It should depict the same guide in a distinct assessment context,
+  not introduce a second mascot.
+- Sibling illustrations may vary pose, crop, and product context, but preserve
+  the mascot's hooded silhouette, calm three-quarter portrait language,
+  monochrome ink treatment, and star-at-the-throat motif. Do not make an exact
+  copy of the Chat artwork.
+- The shared ecosystem block uses `Ziwei Knows / 紫微知道` with the existing
+  mascot as the series visual cue. This establishes a shared IP without
+  implying that one product owns the whole series.
 - Use real product screenshots with descriptive alt text. Do not create generic
   decorative art merely to fill the README.
 

--- a/docs/superpowers/specs/2026-07-21-ziwei-knows-readme-ecosystem-design.md
+++ b/docs/superpowers/specs/2026-07-21-ziwei-knows-readme-ecosystem-design.md
@@ -1,0 +1,121 @@
+# Ziwei Knows README Ecosystem Design
+
+## Goal
+
+Make the three public repositories work as complementary product landing pages
+under the Ziwei Knows brand. README pages should convert visitors into product
+users first and serve setup, deployment, and contribution needs second.
+
+## Product Model
+
+The products are peers, not a forced funnel:
+
+| Product | Public name | Job |
+| --- | --- | --- |
+| Ziwei Chart | Ziwei Knows · Chart | Deterministic chart creation, visual exploration, and trend analysis. |
+| Ziwei Chat | Ziwei Knows · Chat | Evidence-backed AI conversation about chart facts and real questions. |
+| ZATI | Ziwei Knows · Ziwei Archetype Type Indicator | Low-barrier Eastern archetype self-exploration through behavioral choices. |
+
+Ziwei Chart currently has the strongest search and GitHub traffic. It may carry
+more ecosystem discovery links, but it is not positioned as a superior or parent
+product. Every README presents all three products as equal choices for different
+needs.
+
+## Shared README Architecture
+
+All three README files follow this order:
+
+1. Product-specific hero: product name, one-sentence value, product-specific
+   visual, technology and license badges.
+2. Primary action: use the current product. This is the only dominant CTA.
+3. `Ziwei Knows Product Ecosystem`: three peer product cards, current repository
+   marked as `Current product`, and need-based cross-links.
+4. What the current product is and who it helps.
+5. Core capabilities and real screenshots.
+6. Product-specific mechanism and reliability boundaries.
+7. FAQ written as direct answers to real user search questions.
+8. Quick start, configuration, deployment, contribution, and license.
+
+The ecosystem block uses explicit links to repositories and public sites. Until
+the organization migration is complete, links use the existing `ruijayfeng/*`
+locations. They will be updated together after transfer to `ziweiknows/*`.
+
+## Product-Specific Content
+
+### Ziwei Chart
+
+- Keep its multilingual entry points and high-value search terms: Zi Wei Dou Shu
+  chart, true solar time, annual fortune, compatibility chart, and life trend.
+- Make online chart use the primary CTA, then recommend Chat for question-led
+  interpretation and ZATI for behavioral self-exploration.
+- Retain detailed feature screenshots and self-hosting instructions.
+- Add concise FAQ answers about birth data, birthplace matching, true solar
+  time, model configuration, and the difference between Chart and Chat.
+
+### Ziwei Chat
+
+- Preserve the current README's high-information format: calm hero, numbered
+  contents, capability table, architecture diagram, operating modes, and
+  boundaries.
+- Change the main product title to `Ziwei Knows · Chat | Ziwei Chat` in the
+  ecosystem copy while retaining the product personality `Zhiwei`.
+- Recommend Chart for full visual chart exploration and ZATI for users seeking
+  an entry without birth data.
+- Add FAQ answers about deterministic facts, evidence, local mode, privacy, and
+  the relationship with Chart.
+
+### ZATI
+
+- Keep the product distinct from both charting and AI: behavioral choices create
+  the type; Eastern cultural archetypes provide its expression.
+- Lead with the quick and standard assessment CTA, followed by the sixteen
+  archetype result experience.
+- Recommend Chart and Chat only as optional, equal next explorations.
+- Add FAQ answers about diagnosis, scoring, privacy, the 24/56-question modes,
+  and what ZATI does not claim to measure.
+
+## Visual and Logo Rules
+
+Ziwei Chat is the visual reference for information density, hierarchy, dividers,
+tables, and restrained use of assets. It is not a template to copy verbatim.
+
+- Chart keeps the existing `docs/assets/logo.svg` as a Chart-specific hero asset.
+  Its tagline, `let the chart speak`, describes Chart and must not become a
+  series-wide claim.
+- Chat keeps the `Zhiwei` companion mark as its product-specific emotional cue.
+- ZATI keeps a typographic `ZATI` hero until it has an independently designed
+  archetype mark; do not reuse Chat's character or Chart's logo.
+- The shared ecosystem block uses a text brand lockup, `Ziwei Knows / 紫微知道`,
+  rather than a product logo. This avoids implying one product owns
+  the whole series.
+- Use real product screenshots with descriptive alt text. Do not create generic
+  decorative art merely to fill the README.
+
+## GEO and Search Rules
+
+- Each README owns a distinct primary search intent; do not repeat identical
+  product paragraphs or keyword lists across repositories.
+- Put a factual product definition and primary terms in the title, first 160
+  words, headings, image alt text, and FAQ answers.
+- Prefer verifiable claims: named chart engine, deterministic fact boundaries,
+  local-first behavior, question counts, and tested product capabilities.
+- Cross-link with descriptive anchors such as `Ask chart questions in Ziwei
+  Chat`, never vague `click here` links.
+- Preserve Chart's Chinese, Traditional Chinese, Japanese, and English entry
+  points. Add translated README pages to Chat and ZATI only after the Chinese
+  canonical content stabilizes.
+
+## Non-Goals
+
+- No claim that the three products share accounts, profiles, birth data, or
+  results; they currently only share brand and discovery links.
+- No attempt to rank the three products in the ecosystem.
+- No keyword stuffing, synthetic usage metrics, or unsupported AI capability
+  claims.
+
+## Validation
+
+Before release, check that every external link resolves, every screenshot is
+rendered with meaningful alt text, the current product has the clearest CTA,
+cross-links describe a complementary need, and the command/deployment sections
+match the repository's actual scripts and hosting model.


### PR DESCRIPTION
## Summary
- Reframe Ziwei Chart as a product-first README while preserving its search and multilingual entry points.
- Add a peer-level Ziwei Knows ecosystem section linking Chart, Chat, and ZATI by user need.
- Add product-specific FAQ, reliability boundaries, and explicit mascot-art placeholder without new logo assets.

## Verification
- npm run test: 28 passed
- Markdown whitespace, local asset references, and public ecosystem links checked (all links returned 200).